### PR TITLE
Fix wording in best practices section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ This plugin uses the following Systeme.io API endpoints:
 
 4. **Best Practices**:
    - Use descriptive custom field names
-   - Be consistent in mapping naming
-   - Regular check logs for monitoring
+   - Be consistent in mapping names
+   - Regularly check logs for monitoring
    - Consider the comma-separated format when setting up automations
 
 ## Changelog


### PR DESCRIPTION
## Summary
- fix typos in best practices section of README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6841414b3868832eb6978e2ac9e44637